### PR TITLE
type-attribute in script and link tags, css-media handling

### DIFF
--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -41,9 +41,13 @@ function snippet($snippet, $data=array(), $return=false) {
 }
 
 // embed a stylesheet tag
-function css($url, $media='all') {
+function css($url, $media = '') {
   $url = (str::contains($url, 'http://') || str::contains($url, 'https://')) ? $url : url(ltrim($url, '/'));
-  return '<link rel="stylesheet" media="' . $media . '" href="' . $url . '" />' . "\n";
+  if (!empty($media)) {
+    return '<link rel="stylesheet" media="' . $media . '" href="' . $url . '" />' . "\n";
+  } else {
+    return '<link rel="stylesheet" href="' . $url . '" />' . "\n";
+  }
 }
 
 // embed a js tag


### PR DESCRIPTION
When using html5 you can omit the type-attributes for the `<link>` and the `<script>`-Tags when embedding CSS-Files and Javascript, see: http://yatil.de/Weblog/wer-heute-schon-html5-einsetzen-sollte

I prefer defining @media inside the stylesheets and not in the `<link>`-tag to, so maybe just dont set it at all, if the param for the css-function is not set.

Yeah, and my editor config stripped some whitespace :-)
