### PR TITLE
Fix for striped HTML in excerpts

### DIFF
--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -1669,7 +1669,7 @@ class str {
   static function excerpt($string, $chars=140, $removehtml=true, $rep='…') {
     if($removehtml) $string = strip_tags($string);
     $string = str::trim($string);    
-    $string = str_replace("\n", '', $string);
+    $string = str_replace("\n", ' ', $string);
     if(str::length($string) <= $chars) return $string;
     return ($chars==0) ? $string : substr($string, 0, strrpos(substr($string, 0, $chars), ' ')) . $rep;
   }


### PR DESCRIPTION
Fix to avoid line breaks and list elements to be replaced by 'nothing' (actually missing a white space) in excerpts.
