### PR TITLE
patch findByExtension to work with arrays

### DIFF
--- a/kirby/lib/files.php
+++ b/kirby/lib/files.php
@@ -335,19 +335,21 @@ class files extends obj {
 
   function findByExtension() {
 
-    $args  = func_get_args();
-    $count = count($args); 
+    $args = a::first(func_get_args());
+    $count = count($args);
+	
     if($count == 0) return false;
-    
+    if(is_array($args) && $count == 1) $args = a::first($args);
+
     $files = array();
     foreach($this->_ as $key => $file) {
       if($count > 1) {
         if(in_array($file->extension, $args)) $files[$key] = $file;
       } else {
-        if($file->extension == $args[0]) $files[$key] = $file;      
+        if($file->extension == $args) $files[$key] = $file;      
       }
     }   
-    return new files($files);      
+    return new files($files);     
   }
 
   function findByType($type) {


### PR DESCRIPTION
function findByExtension didn't work right when passed extensions in a array like that: array('pdf', 'png')

with this patch you can pass a array of extensions or just a string.
i hope this is not going to break things in other places.

test like that:

snippet('filelist', array(
  'extension' => array('pdf','jpg'),
  'sort'      => 'filename',
  'direction' => 'desc' 
)); 

snippet('filelist', array(
  'extension' => array('jpg'),
  'sort'      => 'filename',
  'direction' => 'desc'
)); 

snippet('filelist', array(
  'extension' => 'gif',
  'sort'      => 'filename',
  'direction' => 'desc'
));
