### PR TITLE
Changes to Plugin API

### DIFF
--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -65,4 +65,13 @@ function param($key, $default=false) {
   return $site->uri->params($key, $default);
 }
 
+// check if plugin exists
+function plugin_active($plugin) {
+  if(file_exists(c::get("root.plugins") . '/' . $plugin . '.php') || file_exists(c::get('root.plugins') . '/' . $plugin . '/' . $plugin . '.php')) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 ?>

--- a/kirby/lib/load.php
+++ b/kirby/lib/load.php
@@ -29,17 +29,24 @@ class load {
     self::file($root . '/config.' . server::get('server_name') . '.php');
   }
   
-  static function plugins() {
+  static function plugins($folder='') {
     $root  = c::get('root.plugins');
-    $files = dir::read($root);    
+    if($folder != '') {
+      $files = dir::read($root . '/' . $folder);
+    } else {
+      $files = dir::read($root); 
+    } 
 
     if(!is_array($files)) return false;
     
     foreach($files as $file) {
-      if(f::extension($file) != 'php') continue;
-      self::file($root . '/' . $file);
+      if(is_dir($root . '/' . $file)) {
+        self::plugins($file . '/');
+      }
+      if(f::extension($file) != 'php' || $file == $folder . '.php') continue;
+      self::file($root . '/' . $folder . $file);
     }
-    
+    self::file($root . '/' . $folder . $folder . '.php');
   }
 
   static function parsers() {


### PR DESCRIPTION
These are some very small (but powerful) changes to the plugin API and are needed for my "Compress" feature, now named "Assety":
1. Now you can put all your plugin files (libraries, classes etc.) into one folder named like the plugin, for example readingtime for the plugin readingtime.
All of the files directly placed in the folder will be included, files in deeper folder structures not since you may don't need them all the time (for example if you have a big library including all the files it needs automatically.
1. There's a new plugin_active() function, checking if a plugin is installed.
