### PR TITLE
Correct HTML5 Semantics in example files

### DIFF
--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -96,3 +96,12 @@ footer a {
 footer a:hover {
   color: #222;
 }
+.hidden {
+  position: absolute; 
+  clip: rect(0 0 0 0); 
+  height: 1px; 
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden; 
+}

--- a/site/snippets/footer.php
+++ b/site/snippets/footer.php
@@ -1,4 +1,5 @@
   <footer>
+  	<h1 class="hidden">Meta information</h1>
     <?php echo kirbytext($site->copyright()) ?>
   </footer>
 

--- a/site/snippets/menu.php
+++ b/site/snippets/menu.php
@@ -1,4 +1,5 @@
 <nav class="menu">
+  <h1 class="hidden">Main navigation</h1>
   <ul>
     <?php foreach($pages->visible() AS $p): ?>
     <li><a<?php echo ($p->isOpen()) ? ' class="active"' : '' ?> href="<?php echo $p->url() ?>"><?php echo html($p->title()) ?></a></li>

--- a/site/snippets/submenu.php
+++ b/site/snippets/submenu.php
@@ -7,6 +7,7 @@ $items = ($open) ? $open->children()->visible() : false;
 ?>
 <?php if($items && $items->count()): ?>
 <nav class="submenu">
+  <h1 class="hidden">Secondary navigation</h1>
   <ul>
     <?php foreach($items AS $item): ?>
     <li><a<?php echo ($item->isOpen()) ? ' class="active"' : '' ?> href="<?php echo $item->url() ?>"><?php echo html($item->title()) ?></a></li>

--- a/site/templates/default.php
+++ b/site/templates/default.php
@@ -3,6 +3,7 @@
 <?php snippet('submenu') ?>
 
 <section class="content">
+  <h1 class="hidden">Main Content</h1>
 
   <article>
     <h1><?php echo html($page->title()) ?></h1>


### PR DESCRIPTION
Every semantic HTML5 element should have a H1 tag to designate its
content. I think it would set a good example for people using those
files as base + Its now even more explicit what the respective snippets
contain.
