### PR TITLE
Protocol-relative URL for css() and js()

### DIFF
--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -65,7 +65,7 @@ function snippet($snippet, $data=array(), $return=false) {
 
 // embed a stylesheet tag
 function css($url, $media=false) {
-  $url = (str::contains($url, 'http://') || str::contains($url, 'https://')) ? $url : url(ltrim($url, '/'));
+  $url = (str::match($url, '~(^\/\/|^https?:\/\/)~'))? $url : url(ltrim($url, '/'));
   if(!empty($media)) {
     return '<link rel="stylesheet" media="' . $media . '" href="' . $url . '" />' . "\n";
   } else {
@@ -75,7 +75,7 @@ function css($url, $media=false) {
 
 // embed a js tag
 function js($url) {
-  $url = (str::contains($url, 'http://') || str::contains($url, 'https://')) ? $url : url(ltrim($url, '/'));
+  $url = (str::match($url, '~(^\/\/|^https?:\/\/)~'))? $url : url(ltrim($url, '/'));
   return '<script src="' . $url . '"></script>' . "\n";
 }
 


### PR DESCRIPTION
> css() and js() allows you to use a protocol-relative URL now (eg. "//html5shiv.googlecode.com/svn/trunk/html5.js").

Matching "http://", "https://", and "//" now.

Best,
Fabian
