### PR TITLE
custom setting for files to ignore

### DIFF
--- a/kirby/defaults.php
+++ b/kirby/defaults.php
@@ -22,6 +22,9 @@ c::set('root.parsers',   c::get('root.kirby') . '/parsers');
 c::set('scheme', (server::get('https')) ? 'https://' : 'http://');
 c::set('url', c::get('scheme') . server::get('http_host'));
 
+// ignore files
+c::set('files.ignore', array('.svn'));
+
 // rewrite url setup
 c::set('rewrite', true);
 

--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -1678,7 +1678,7 @@ class dir {
    */
   static function read($dir) {
     if(!is_dir($dir)) return false;
-    $skip = array('.', '..', '.DS_Store');
+    $skip = array_merge(c::get('files.ignore', array()), array('.', '..', '.DS_Store'));
     return array_diff(scandir($dir),$skip);
   }
 


### PR DESCRIPTION
Hi,

I am testing kirbyCMS and use subversion for VCS and noticed, that kirby includes the .svn-folders when traversing the content-directory.

I added a custom settings to ignore these files if wanted.

BTW nice work!
