### PR TITLE
Added a new helper function: "debug"

### DIFF
--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -86,12 +86,8 @@ function param($key, $default=false) {
 }
 
 // debug function
-function debug($msg, $die=false) {
-  if($die && c::get('debug')) {
-    die("<strong>" . $msg . "</strong>");
-  } else if($die) {
-    die();
-  } else if(c::get('debug')) {
+function debug($msg) {
+  if(c::get('debug')) {
     echo $msg;
     return true;
   }


### PR DESCRIPTION
With this debug() function you can easily throw an error from a plugin for example. The error will just be echoed when the "debug" config var is set to true.

Usage:
$echoed = debug($msg, $die);

$msg: The message to output

$die:
true for "bad error, die() with the message" (will also be used when debug() is not set, but if debug=false nothing will be echoed, it will just die (like a fatal PHP error),
false for "normal echo output, only if debug enabled (like a notice).

$echoed: Returns if something was echoed, of course only if $die is false ;)
