### PR TITLE
Added ability for plugins to have an assets folder

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,7 +21,8 @@ RewriteBase /
 # block text files in the content folder from being accessed directly
 RewriteRule ^content/(.*)\.txt$ error [R=301,L]
 
-# block all files in the site folder from being accessed directly
+# block all files in the site folder from being accessed directly but let plugin assets be accessible
+RewriteCond %{REQUEST_URI} !^/site/plugins/.+?/assets/.*
 RewriteRule ^site/(.*) error [R=301,L]
 
 # block all files in the kirby folder from being accessed directly

--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -88,8 +88,7 @@ function param($key, $default=false) {
 // let plugins get the file name of their own assets
 function getpluginasset($whichone) {
   $backtrace = debug_backtrace();
-  preg_match('{^(.*)/.*}', $backtrace[0]["file"], $matches);
-  $assetfolder = "/" . c::get('subfolder') . str_replace(c::get('root') . "/", "", $matches[1]) . "/assets/";
+  $assetfolder = "/" . c::get('subfolder') . str_replace(c::get('root') . "/", "", dirname($backtrace[0]["file"])) . "/assets/";
   $file = $assetfolder . $whichone;
   return $file;
 }

--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -84,3 +84,12 @@ function param($key, $default=false) {
   global $site;
   return $site->uri->params($key, $default);
 }
+
+// let plugins get the file name of their own assets
+function getpluginasset($whichone) {
+  $backtrace = debug_backtrace();
+  preg_match('{^(.*)/.*}', $backtrace[0]["file"], $matches);
+  $assetfolder = "/" . c::get('subfolder') . str_replace(c::get('root') . "/", "", $matches[1]) . "/assets/";
+  $file = $assetfolder . $whichone;
+  return $file;
+}


### PR DESCRIPTION
Now every plugin can have a folder named "assets" inside of the plugin folder with CSS-, JS-files and images and whatever, which is accessible over the internet (there is a new RewriteCond for this).

To make it a lot easier for plugins to get the right URL to an asset, it can now just call "getpluginasset($name)" to get a specific file URL, for example "getpluginasset('file.css')" will return "/site/plugins/ANYTHING/assets/file.css".
The great thing: The current plugin is auto detected, so there is no  need to pass the name manually. So plugins can even be installed to another folder (I will make a pull request soon) and it will still work.

Cool, em?