### PR TITLE
Multiple plugin folders

### DIFF
--- a/kirby/lib/load.php
+++ b/kirby/lib/load.php
@@ -29,17 +29,27 @@ class load {
     self::file($root . '/config.' . server::get('server_name') . '.php');
   }
   
-  static function plugins($folder=false) {
+  static function plugins($folder=false, $ignoreroot=false) {
 
     $root   = c::get('root.plugins');
     $folder = ($folder) ? $folder : $root;
     $files  = dir::read($folder);
+    
+    if($folder == $root) {
+      foreach(c::get('pluginfolders') as $pluginfolder) {
+	      if(substr($pluginfolder, 0, 1) == "/") {
+		      self::plugins($pluginfolder, true);
+	      } else {
+		      self::plugins(c::get('root') . '/' . $pluginfolder, true);
+	      }
+      }
+    }
 
     if(!is_array($files)) return false;
     
     foreach($files as $file) {
       
-      if(is_dir($folder . '/' . $file) && $folder == $root) {
+      if(is_dir($folder . '/' . $file) && ($folder == $root || $ignoreroot)) {
         self::plugins($folder . '/' . $file);
         continue;
       }

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -127,6 +127,29 @@ c::set('ssl', false);
 /*
 
 ---------------------------------------
+Plugins
+---------------------------------------
+
+If you have multiple sites powered by the same
+Kirby installation, as described here:
+,
+you can define additional folders in this array to be used as plugin folders.
+
+Every folder defined here (absolute or relative to the Kirby installation folder
+defined as $root) will be searched for .php files and plugin folders to include as
+a normal plugin.
+
+Notice: The normal site/plugins/ folder will be used by default and
+can't be deactivated, you don't have to define it here!
+
+*/
+
+c::set('pluginfolders', array());
+
+
+/*
+
+---------------------------------------
 Kirbytext Setup 
 ---------------------------------------
 


### PR DESCRIPTION
With this feature the user can add another (or multiple) new folders searched for plugins.

This is great, if the user has multiple sites powered by the same Kirby installation and wants both sites to have a specific plugin. Instead of installing (and updating…) the plugin in both site/plugins/ folders or even symlink it, you can now define all folders with plugins in the config.php of each site.

The given folder names can either be relative to the Kirby installation or absolute (to the partition of course :D).

BTW I now make pull requests to your dev branch, better, hm? :D
