### PR TITLE
Made a "dynamic" cache function

### DIFF
--- a/kirby/lib/site.php
+++ b/kirby/lib/site.php
@@ -206,8 +206,35 @@ class site extends obj {
       $html = $cacheData;
     }
     
-    eval("?> $html <?php ");
-    die();
+    // check for cacheless snippets and replace them all
+    if(preg_match_all('/{{run:(?: )?(.+?)}}/', $html, $matches, PREG_SET_ORDER)) {
+
+			foreach($matches as $match) {
+				$options = $match[1];
+				$optionarray = preg_split('{ ?\| ?}', $options);
+
+				$first = true;
+				$params = array();
+				foreach($optionarray as $option) {
+					if($first == true) {
+						$function = $option;
+						$first = false;
+						continue;
+					}
+					
+					$eval = '$params[] = ' . $option . ";";
+					eval($eval);
+				}
+				
+				ob_start();
+				call_user_func_array($function, $params);
+				$data = ob_get_clean();
+
+				$html = str_replace($match[0], $data, $html);
+			}          
+    }
+
+    die($html);
     
   }
   


### PR DESCRIPTION
As needed for plugins showing dynamic things like comments I added an eval() to cache the PHP code (not the output) but still echo it the right way.

That works like that:
In a template file (or snippet or plugin called from a template or whatever, it's all the same) you can write things like that, to echo PHP code:

``` php
<?php echo "<?php phpinfo(); ?>"; ?>
```

or access Kirby vars and helpers (bad example but works…):

``` php
<?php echo "<?php print_r($page); ?>"; ?>
```

Then, exactly that (the PHP code) will be cached, but before outputting that to the browser, all that stuff will be evaluated to get the comments or whatever.
So all is cached (saving more time to generate output) but all stuff that needs to be dynamic is dynamic. :)

OK, the syntax above is not perfect, but otherwise it would be evaluated directly…
