### PR TITLE
Removed that strange design predecision for Kirbytext code blocks

### DIFF
--- a/kirby/parsers/kirbytext.php
+++ b/kirby/parsers/kirbytext.php
@@ -110,11 +110,7 @@ class kirbytext {
     $code  = trim($code);
 
     if(function_exists('highlight')) {
-      $result  = '<pre class="highlight ' . $first . '">';
-      $result .= '<code>';
-      $result .= highlight($code, (empty($first)) ? 'php-html' : $first);
-      $result .= '</code>';
-      $result .= '</pre>';
+      $result  = (empty($first)) ? highlight($code, 'php-html') : highlight($code, $first);
     } else {
       $result  = '<pre class="' . $first . '">';
       $result .= '<code>';


### PR DESCRIPTION
The highlight() function must now return the whole code including `<pre>` and `<code>`, because it was just a thing some people might not want to have.

I need a specific class in the `<pre>` tag to make this work with the beautiful Prism.js, so it would be great, if I had the ability to do that.

Now, you can easily return whatever you want.

Will change that for the highlight plugin as well.