### PR TITLE
Create slug for pages

### DIFF
--- a/kirby/lib/pages.php
+++ b/kirby/lib/pages.php
@@ -146,6 +146,10 @@ class page extends obj {
     return u('x/' . $this->hash());
   }
 
+  function slug() {
+    return end(explode('/', $this->url()));
+  }
+
   function date($format=false) {
     if(!$this->date) return false;
     $date = strtotime($this->_['date']);


### PR DESCRIPTION
It's an unobtrusive change for beginners but useful for more complex styling in templates and pages, for example, page specific styles: 

```
<body class="<?php echo $page->slug() ?>">
```

So my folder with name of "brand-guide" results in:

```
<body class="brand-guide">
```
