### PR TITLE
Fixed fatal error for multi-language error pages

### DIFF
--- a/kirby/lib/site.php
+++ b/kirby/lib/site.php
@@ -131,7 +131,7 @@ class site extends obj {
               foreach(c::get('lang.available') as $lang) {
                 $c = $child->content($lang);   
                 // redirect to the url if a translated url has been found
-                if($c->url_key() == $p && !$child->isErrorPage()) $next = $child;
+                if(is_object($c) && $c->url_key() == $p && !$child->isErrorPage()) $next = $child;
               }
             }
 


### PR DESCRIPTION
When calling non-existent URLs with multi language support enabled, PHP died with a fatal error ("Call to a member function url_key() on a non-object").
This is now fixed.
