### PR TITLE
Wrap Kirby Text Video Embed iFrames With A Div

### DIFF
--- a/kirby/parsers/kirbytext.php
+++ b/kirby/parsers/kirbytext.php
@@ -385,7 +385,7 @@ class kirbytext {
     // add a classname to the iframe
     if(!empty($class)) $class = ' class="' . $class . '"';
 
-    return '<iframe' . $class . ' width="' . $params['width'] . '" height="' . $params['height'] . '" src="' . $url . '" frameborder="0" allowfullscreen></iframe>';
+    return '<div class="video-container"><iframe' . $class . ' width="' . $params['width'] . '" height="' . $params['height'] . '" src="' . $url . '" frameborder="0" allowfullscreen></iframe></div>';
   
   }
 


### PR DESCRIPTION
This is a refinement to the output of Kirby Text's method for embedding YouTube and Vimeo videos.

With the popularity of responsive design and to generally gain more control over the embed, I want to suggest wrapping the `iFrame` in a `div` with a `class` of `video-container`. Now you can utilize tools like [FitVids.js](https://github.com/davatron5000/FitVids.js) to make these video embeds fluid.
