### PR TITLE
file() accepts glob pattern ("*en.php"); multiple files for one language in "languages" folder.

### DIFF
--- a/kirby/lib/load.php
+++ b/kirby/lib/load.php
@@ -69,16 +69,18 @@ class load {
 
   static function language() {
     $root    = c::get('root.site') . '/languages';
-    $default = $root . '/' . c::get('lang.default') . '.php';    
-    $current = $root . '/' . c::get('lang.current') . '.php';    
+    $default = $root . '/*' . c::get('lang.default') . '.php';    
+    $current = $root . '/*' . c::get('lang.current') . '.php';    
     
     self::file($default);
     self::file($current);
   }
   
-  static function file($file) {
-    if(!file_exists($file)) return false;
-    require_once($file);    
+  static function file($file_glob) {
+    foreach (glob($file_glob) as $filename):
+      if(file_exists($filename)) require_once($filename);
+    endforeach;
+    return false;
   }
 
 }

--- a/kirby/lib/site.php
+++ b/kirby/lib/site.php
@@ -258,7 +258,7 @@ class site extends obj {
   function rootPages() {
   
     // get the first level in the content root
-    $ignore = array_merge(array('.svn', '.git', '.htaccess'), (array)c::get('content.file.ignore', array()));
+    $ignore = array_merge(array('.svn', '.git', '.hg', '.htaccess'), (array)c::get('content.file.ignore', array()));
     $files  = dir::inspect(c::get('root.content'), $ignore);
     $pages  = array();
     


### PR DESCRIPTION
I updated "file()" so that it can also accept glob pattern ("*en.php") 
and include (require) all matched files. Totally backwards compatible.

The reason for this is to allow multiple files for one language in
"languages" folder. Now I can translate my plugin like this:

site/languages/plugin-name.en.php
site/languages/plugin-name.ru.php

and keep other translations in the same folder:
site/languages/en.php
site/languages/ru.php

and they all will load together. Handy!
