### PR TITLE
Filename-based cache busting. (resubmitting)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -58,7 +58,9 @@
 # CSS and JavaScript
   ExpiresByType application/javascript    "access plus 1 year"
   ExpiresByType text/css                  "access plus 1 year"
-  
+
+</IfModule>
+
 # ----------------------------------------------------------------------
 # Prevent mobile network providers from modifying your site
 # ----------------------------------------------------------------------
@@ -85,7 +87,6 @@
 #   developer.yahoo.com/performance/rules.html#etags
 FileETag None
 
-</IfModule>
 
 # ----------------------------------------------------------------------
 # Rewrite rules

--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,96 @@
 # Kirby .htaccess
 
-# rewrite rules
+# ----------------------------------------------------------------------
+# Expires headers (for better cache control)
+# ----------------------------------------------------------------------
+
+# These are pretty far-future expires headers.
+# They assume you control versioning with filename-based cache busting
+# Additionally, consider that outdated proxies may miscache
+#   www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/
+
+# If you don't use filenames to version, lower the CSS and JS to something like
+# "access plus 1 week".
+
+<IfModule mod_expires.c>
+  ExpiresActive on
+
+# Perhaps better to whitelist expires rules? Perhaps.
+  ExpiresDefault                          "access plus 1 month"
+
+# cache.appcache needs re-requests in FF 3.6 (thanks Remy ~Introducing HTML5)
+  ExpiresByType text/cache-manifest       "access plus 0 seconds"
+
+# Your document html
+  ExpiresByType text/html                 "access plus 0 seconds"
+
+# Data
+  ExpiresByType application/json          "access plus 0 seconds"
+  ExpiresByType application/xml           "access plus 0 seconds"
+  ExpiresByType text/xml                  "access plus 0 seconds"
+
+# Feed
+  ExpiresByType application/atom+xml      "access plus 1 hour"
+  ExpiresByType application/rss+xml       "access plus 1 hour"
+
+# Favicon (cannot be renamed)
+  ExpiresByType image/x-icon              "access plus 1 week"
+
+# Media: images, video, audio
+  ExpiresByType audio/ogg                 "access plus 1 month"
+  ExpiresByType image/gif                 "access plus 1 month"
+  ExpiresByType image/jpeg                "access plus 1 month"
+  ExpiresByType image/png                 "access plus 1 month"
+  ExpiresByType video/mp4                 "access plus 1 month"
+  ExpiresByType video/ogg                 "access plus 1 month"
+  ExpiresByType video/webm                "access plus 1 month"
+
+# HTC files  (css3pie)
+  ExpiresByType text/x-component          "access plus 1 month"
+
+# Webfonts
+  ExpiresByType application/vnd.ms-fontobject "access plus 1 month"
+  ExpiresByType application/x-font-ttf    "access plus 1 month"
+  ExpiresByType application/x-font-woff   "access plus 1 month"
+  ExpiresByType font/opentype             "access plus 1 month"
+  ExpiresByType image/svg+xml             "access plus 1 month"
+
+# CSS and JavaScript
+  ExpiresByType application/javascript    "access plus 1 year"
+  ExpiresByType text/css                  "access plus 1 year"
+  
+# ----------------------------------------------------------------------
+# Prevent mobile network providers from modifying your site
+# ----------------------------------------------------------------------
+
+# The following header prevents modification of your code over 3G on some
+# European providers.
+# This is the official 'bypass' suggested by O2 in the UK.
+
+# <IfModule mod_headers.c>
+# Header set Cache-Control "no-transform"
+# </IfModule>
+
+# ----------------------------------------------------------------------
+# ETag removal
+# ----------------------------------------------------------------------
+
+# FileETag None is not enough for every server.
+<IfModule mod_headers.c>
+  Header unset ETag
+</IfModule>
+
+# Since we're sending far-future expires, we don't need ETags for
+# static content.
+#   developer.yahoo.com/performance/rules.html#etags
+FileETag None
+
+</IfModule>
+
+# ----------------------------------------------------------------------
+# Rewrite rules
+# ----------------------------------------------------------------------
+
 <IfModule mod_rewrite.c>
 
 # enable awesome urls. i.e.: 
@@ -26,6 +116,19 @@ RewriteRule ^site/(.*) error [R=301,L]
 
 # block all files in the kirby folder from being accessed directly
 RewriteRule ^kirby/(.*) error [R=301,L]
+
+# ----------------------------------------------------------------------
+# Built-in filename-based cache busting (from: https://github.com/h5bp/html5-boilerplate/blob/master/.htaccess)
+# ----------------------------------------------------------------------
+
+# routes requests for `/css/style.20110203.css` to `/css/style.css`.
+
+# To understand why this is important and a better idea than all.css?v1231,
+# please refer to the following https://github.com/h5bp/html5-boilerplate/blob/master/doc/htaccess.md#cache-busting.
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.+)\.(\d+)\.(js|css|png|jpg|gif)$ $1.$3 [L]
 
 # make panel links work
 RewriteCond %{REQUEST_FILENAME} !-f

--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -13,8 +13,8 @@ function url($uri=false, $lang=false) {
   // so we need to make sure that this is not a link to a real
   // file. Otherwise it will be broken by the rest of the code. 
   if($uri && is_file(c::get('root') . '/' . $uri)) {
-    if(c::get('versioning')) {
-      $path = pathinfo($uri);
+    $path = pathinfo($uri);
+    if(c::get('versioning') && preg_match('/js|css|png|jpg|gif/', $path['extension'])) {
       $ver_uri = $path['dirname'].'/'.str_replace($path['extension'], filemtime(c::get('root') . '/' . $uri).'.'.$path['extension'], $path['basename']);
       return $baseUrl . '/' . $ver_uri;
     }

--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -13,7 +13,14 @@ function url($uri=false, $lang=false) {
   // so we need to make sure that this is not a link to a real
   // file. Otherwise it will be broken by the rest of the code. 
   if($uri && is_file(c::get('root') . '/' . $uri)) {
-    return $baseUrl . '/' . $uri;          
+    if(c::get('versioning')) {
+      $path = pathinfo($uri);
+      $ver_uri = $path['dirname'].'/'.str_replace($path['extension'], filemtime(c::get('root') . '/' . $uri).'.'.$path['extension'], $path['basename']);
+      return $baseUrl . '/' . $ver_uri;
+    }
+    else {
+      return $baseUrl . '/' . $uri;
+    }         
   }
     
   // prepare the lang variable for later

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -270,6 +270,35 @@ c::set('cache.ignore', array());
 /*
 
 ---------------------------------------
+Cache busting
+---------------------------------------
+
+This works in combination with filename-based cache busting
+rewrites in .htaccess which are active by default. If you
+turn this option off you may comment the following out in
+.htaccess:
+
+<IfModule mod_rewrite.c>
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule ^(.+)\.(\d+)\.(js|css|png|jpg|gif)$ $1.$3 [L]
+</IfModule>
+
+If you turn versioning off you should also review the cache
+times in .htaccess and lower the CSS and JS to something like
+"access plus 1 week".
+
+Turning 'versioning' on places a timestamp code into local resource
+paths ( `/css/style.css' becomes '/css/style.20110203.css') in 
+order to force refreshes in the case of far-future headers.
+
+*/
+
+c::set('versioning', true);
+
+/*
+
+---------------------------------------
 Timezone Setup 
 ---------------------------------------
 


### PR DESCRIPTION
Expires headers and filename-based cache busting as implemented in HTML5 Boilerplate.

Far-future headers and rewrite rules added to .htaccess.
Timestamp versioning added to url() helper.
'versioning' variable added to site/config/config.php.
