### PR TITLE
Corrected second parameter for tpl::load

### DIFF
--- a/kirby/lib/site.php
+++ b/kirby/lib/site.php
@@ -200,7 +200,7 @@ class site extends obj {
             
     if(empty($cacheData)) {
       // load the main template
-      $html = tpl::load($page->template(), false, true);
+      $html = tpl::load($page->template(), array(), true);
       if($this->htmlCacheEnabled) cache::set($cacheID, (string)$html, true);
     } else {
       $html = $cacheData;


### PR DESCRIPTION
the second argument for `tpl::load` should be an array to avoid a warning:

```
extract() expects parameter 1 to be array, boolean given
```
