### PR TITLE
tpl::loadFile now checks that `$vars` is an array

### DIFF
--- a/kirby/lib/template.php
+++ b/kirby/lib/template.php
@@ -27,6 +27,9 @@ class tpl {
   
   static function loadFile($file, $vars=array(), $return=false) {
     if(!file_exists($file)) return false;
+    if(!is_array($vars)) {
+        $vars = array();
+    }
     @extract(self::$vars);
     @extract($vars);
     content::start();


### PR DESCRIPTION
When using an error control operator, errors are still propagated to custom error handlers. This particular error is simple enough that it's worth avoiding altogether.

```
extract() expects parameter 1 to be array, boolean given C:\...path...\kirby\lib\template.php 31
```
