### PR TITLE
Updating readme to include minimal virtualhost config for mod_rewrite to work with .htaccess files

### DIFF
--- a/readme.mdown
+++ b/readme.mdown
@@ -26,7 +26,7 @@ Visit <http://yourdomain.com> (you should probably replace that with your url :)
 
 After you've purchased a license for Kirby, please add your license code to site/config/config.php:
 
-c::set('license', 'put your license code here');
+	c::set('license', 'put your license code here');
 
 
 ### Running Kirby in a subfolder of your domain
@@ -41,12 +41,12 @@ Afterwards make sure to also set the subfolder name:
 
 	c::set('subfolder', 'mySubfolderName');
 
-You probably also need to adjust the RewriteBase in the .htaccess file if you want to use mod_rewrite. You will find more information about all this in the default config file and the htaccess file.
+You probably also need to adjust the RewriteBase in the `.htaccess` file if you want to use mod_rewrite. You will find more information about all this in the default config file and the `.htaccess` file.
 
 
 ### URL Rewriting
 
-If you are not allowed to have your own .htaccess file or to use mod_rewrite, go to `site/config/config.php` and search for the part where you can switch off url rewriting. 
+If you are not allowed to have your own `.htaccess` file or to use mod_rewrite, go to `site/config/config.php` and search for the part where you can switch off url rewriting. 
 
 
 #### Trouble with URL Rewriting?


### PR DESCRIPTION
A Kirby site's VirtualHost must have the  `AllowOvverride` directive set to include `FileInfo` and `Options` (or be set to `All`) for the site's directory in order for Rewrite directives to take effect in `.htaccess` files.

I scoured your site for hours looking for a clue as to why url rewriting didn't work on my local machine, and didn't find any references to this possible issue.

Making a note of it in your readme for future, frustrated, non-apache-experts trying to figure out why url-rewriting may be broken.

You may want to add a note of it somewhere on the kirby site as well.

Thanks!
