### PR TITLE
Use the 404 settings from the configuration for notFound redirects

### DIFF
--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -55,7 +55,7 @@ function home() {
 
 // go to error page
 function notFound() {
-  go(url('error'));
+  go(url(c::get('404')));
 }
 
 // embed a template snippet from the snippet folder

--- a/kirby/lib/site.php
+++ b/kirby/lib/site.php
@@ -448,7 +448,7 @@ class site extends obj {
     
     // http://yourdomain.com/error
     // will redirect to http://yourdomain.com/en/error
-    if($code == c::get('404')) go(url('error', c::get('lang.default')));
+    if(strpos($uri, c::get('404')) === 0) go(url(c::get('404'), c::get('lang.default')));
             
     // validate the code and switch back to the homepage if it is invalid
     if(!in_array($code, c::get('lang.available'))) go(url());


### PR DESCRIPTION
I currently write a small restful api for my online portfolio and needed to handle different error response codes.  Watching the source code I found the little helper method notFound(). I am a bit confused as the method is not using the folder specified in the configuration but is redirecting to the hardcoded error page instead.

Is that the expected behavior? A fix would be trivial and would allow to customize the path/uri used. Even more useful: kirby would send the correct header for the error response if the option 404.header is enabled.

 Of course I could simply use go(url('404')), unfortunatly this method allows only for the response codes: 301, 302 and 303 and I would have to set the 404 response header in my template file.
