### PR TITLE
replace str_replace in parseName

### DIFF
--- a/kirby/lib/pages.php
+++ b/kirby/lib/pages.php
@@ -416,7 +416,7 @@ class page extends obj {
 
     if(str::contains($name, '-')) {
       $match = str::match($name, '!^([0-9]+[\-]+)!', 0);	
-      $uid   = str_replace($match, '', $name);
+      $uid   = substr_replace($name, '', 0, strlen($match));
       $num   = trim(rtrim($match, '-'));
     } else {
       $num   = false;


### PR DESCRIPTION
Only replace the match at the beginning of the string. Ran into trouble with folders named like ‘12-2012-05-13’.
