### PR TITLE
Don't rewrite robots.txt

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,6 +27,9 @@ RewriteRule ^site/(.*) error [R=301,L]
 # block all files in the kirby folder from being accessed directly
 RewriteRule ^kirby/(.*) error [R=301,L]
 
+# leave robots.txt alone for search engines
+RewriteRule ^robots.txt robots.txt [L]
+
 # make panel links work
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
Leave `robots.txt` alone, esp. so we can point robots to the proper sitemap, if we have multi-language setup with prepended URLs, e.g. `/de/sitemap.xml`
