### PR TITLE
Allow to format the site's modified timestamp

### DIFF
--- a/kirby/lib/site.php
+++ b/kirby/lib/site.php
@@ -390,8 +390,8 @@ class site extends obj {
         
   }
   
-  function modified() {
-    return ($this->modified) ? $this->modified : time();
+  function modified($format=false) {
+    return ($this->modified) ? ($format ? date($format, $this->modified) : $this->modified) : ($format ? date($format) : time());
   }
 
   function dataCacheID() {


### PR DESCRIPTION
Lately I tried to format the site's modifed timestamp (to use it in my xml sitemap). In contrast to the equivalent method for page objects a format string is not supported though. A quick fix helps to improve consistency.
