### PR TITLE
Manipulated method findByUID for giving back a single page object, when ...

### DIFF
--- a/kirby/lib/pages.php
+++ b/kirby/lib/pages.php
@@ -565,6 +565,9 @@ class pages extends obj {
 
   function findByUID() {
     $args = func_get_args();
+    if (1 === count($args)) {
+      return $this->findBy('uid', $args[0]);
+    }
     return $this->findBy('uid', $args);
   }
 


### PR DESCRIPTION
...the method only gets one argument

Because a UID is handled as a primary key, so if you search for one site by UID you except a page object will be returned.
Now backwards compability is considered in this commit, replaces #81
