### PR TITLE
added findByTemplate()

### DIFF
--- a/kirby/lib/pages.php
+++ b/kirby/lib/pages.php
@@ -547,6 +547,15 @@ class pages extends obj {
     }    
   }
 
+  function findByTemplate($template) {
+    static $result = array();
+    foreach($this->_ as $key => $page) {
+      if($page->template() == $template) $result[$page->uid] = $page;
+      if($page->hasChildren()) $page->children()->findByTemplate($template);
+    }
+    return new pages($result);
+  }
+
   function findBy($key, $value) {
     if(is_array($value)) {
       $result = array();


### PR DESCRIPTION
Returns new pages set with all pages with specified template. (I used this to return all portfolio objects from different sections of a site)
Not sure if something like this was already incorporated, I Couldn' find anything..
