### PR TITLE
Adding support for content-specified template files

### DIFF
--- a/kirby/lib/pages.php
+++ b/kirby/lib/pages.php
@@ -134,18 +134,29 @@ class page extends obj {
     return ($this->prevVisible($sort, $direction)) ? true : false; 
   }
 
+  function getTemplateFile($name) {
+    return c::get('root.templates') . '/' . $name . '.php';
+  }
+
   function template() {
-
     $name = (!$this->intendedTemplate) ? c::get('tpl.default') : $this->intendedTemplate;
-    
-    // construct the template file 
-    $file = c::get('root.templates') . '/' . $name . '.php';
-    
-    // check if the template file exists and go back to the fallback    
-    if(!file_exists($file)) $name = c::get('tpl.default');
 
+    // construct the template file
+    $file = $this->getTemplateFile($name);
+
+    // check if the template file exists and go back to the specified on the contents
+    // if none, then go to fallback
+    if (!file_exists($file)) {
+      if ($this->_['template'] && file_exists($this->getTemplateFile($this->_['template']))) {
+        // if user specified a template file on the content, and this template
+        // exists, then we'll use it
+        $name = $this->_['template'];
+      } else {
+        // fallback to default, if none of the files exist
+        $name = c::get('tpl.default');
+      }
+    }
     return $name;
-        
   }
 
   function hasTemplate() {


### PR DESCRIPTION
Basically we should have a way to specify custom templates on the content file, such as:

```
Title: My Custom Page
-----
template: my_custom_template
```

The template file (on the `template` variable) will be loaded if:
1. The `intendedTemplate` is `false`.
2. If the template file, defined in the `template` attribute is available and exists.

This is very handy for special cases, for example, when we have a catalog of products and we want to have one special template file for a single product (not all of them).
