### PR TITLE
Add past() method to pages class in pages.php

### DIFF
--- a/kirby/lib/pages.php
+++ b/kirby/lib/pages.php
@@ -743,6 +743,21 @@ class pages extends obj {
     return new pages($result);    
       
   }
+  
+  function past($start = 0, $end = false){
+    if(!$end) $end = time();
+
+    foreach($this->_ as $key => $page) {
+      $page_date = strtotime($page->date('Y-m-d H:i'));
+      
+      if($start < $page_date && $page_date < $end) {
+        $pages[$key] = $page;
+      }
+    }
+    
+    return new pages($pages);
+    
+  }
             
 }
 


### PR DESCRIPTION
past() method allows for chainable filtering of pages by date range. Default behavior without any arguments is to return all pages with a date set before today. Supports date and time for to-the-minute scheduled publication.
