### PR TITLE
Improving url() compatibility with local files.

### DIFF
--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -12,7 +12,7 @@ function url($uri=false, $lang=false) {
   // url() can also be used to link to css, img or js files
   // so we need to make sure that this is not a link to a real
   // file. Otherwise it will be broken by the rest of the code. 
-  if($uri && is_file(c::get('root') . '/' . $uri)) {
+  if($uri && is_file(c::get('root') . '/' . preg_replace('/(\?|#).*$/is', '', $uri))) {
     return $baseUrl . '/' . $uri;          
   }
     


### PR DESCRIPTION
This patch lets `url()` remove the query string and hash from the URI before checking if the specified file exists on the server. Kirby includes `url::strip_query()` and `url::strip_hash()` but no function that does both, therefor a new regular expression was created.

(I first tried `[?#].*$` but this seemed to work inconsistently on my PHP version.)

Fixes #97.
