### PR TITLE
Preserve existing HTML entities.

### DIFF
--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -2594,9 +2594,9 @@ class str {
     */  
   static function html($string, $keep_html=true) {
     if($keep_html) {
-      return stripslashes(implode('', preg_replace('/^([^<].+[^>])$/e', "htmlentities('\\1', ENT_COMPAT, 'utf-8')", preg_split('/(<.+?>)/', $string, -1, PREG_SPLIT_DELIM_CAPTURE))));
+      return stripslashes(implode('', preg_replace('/^([^<].+[^>])$/e', "str::html('\\1', false)", preg_split('/(<.+?>)/', $string, -1, PREG_SPLIT_DELIM_CAPTURE))));
     } else {
-      return htmlentities($string, ENT_COMPAT, 'utf-8');
+      return preg_replace('/(?<=&)amp;(?=#?[xX]?(?:[0-9a-fA-F]+|\w+);)/', '', htmlentities($string, ENT_COMPAT, 'utf-8'));
     }
   }
 


### PR DESCRIPTION
This patch changes the way `str::html` handles ampersands (`&`) and with that updates Kirbytext to preserve HTML entities, fixing problems such as #104.

This patch adapts the Ampersand-encoding regular expression from PHP Markdown (“based entirely on [Nat Irons’s Amputator](http://bumppo.net/projects/amputator/)”) but flips it around: decoding `&amp;`s wrongfully encoded by PHP’s `htmlentities`.

Note that this further distances the `kirby.php` file shipped with Kirby from the [Kirby Toolkit](https://github.com/bastianallgeier/kirby). This changes the `str::html` without regard for bastianallgeier/kirby#31, specifically to not change the [PHP requirements of Kirby](http://getkirby.com/hosting) from 5.2+ to 5.3+.
