### PR TITLE
Trim whitespace from beginning and end of output

### DIFF
--- a/kirby/lib/helpers.php
+++ b/kirby/lib/helpers.php
@@ -59,8 +59,8 @@ function notFound() {
 }
 
 // embed a template snippet from the snippet folder
-function snippet($snippet, $data=array(), $return=false) {
-  return tpl::loadFile(c::get('root.snippets') . '/' . $snippet . '.php', $data, $return);
+function snippet($snippet, $data=array(), $return=false, $trim=true) {
+  return tpl::loadFile(c::get('root.snippets') . '/' . $snippet . '.php', $data, $return, $trim);
 }
 
 // embed a stylesheet tag

--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -803,9 +803,12 @@ class content {
     * @param  boolean  $return Pass true to return the content instead of flushing it 
     * @return mixed
     */
-  static function end($return=false) {
+  static function end($return=false, $trim=false) {
     if($return) {
-      $content = trim(ob_get_contents());
+      $content = ob_get_contents();
+      if($trim) {
+        $content = trim($content);
+      }
       ob_end_clean();
       return $content;
     }

--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -805,7 +805,7 @@ class content {
     */
   static function end($return=false) {
     if($return) {
-      $content = ob_get_contents();
+      $content = trim(ob_get_contents());
       ob_end_clean();
       return $content;
     }

--- a/kirby/lib/template.php
+++ b/kirby/lib/template.php
@@ -20,12 +20,12 @@ class tpl {
     return a::get(self::$vars, $key, $default);       
   }
 
-  static function load($template='default', $vars=array(), $return=false) {    
+  static function load($template='default', $vars=array(), $return=false, $trim=true) {
     $file = c::get('root.templates') . '/' . $template . '.php';
-    return self::loadFile($file, $vars, $return);
+    return self::loadFile($file, $vars, $return, $trim);
   }
   
-  static function loadFile($file, $vars=array(), $return=false) {
+  static function loadFile($file, $vars=array(), $return=false, $trim=true) {
     if(!file_exists($file)) return false;
     if(!is_array($vars)) {
         $vars = array();
@@ -34,7 +34,7 @@ class tpl {
     @extract($vars);
     content::start();
     require($file);
-    return content::end($return); 
+    return content::end($return, $trim);
   }
 
 }


### PR DESCRIPTION
This makes sure that accidental blank lines in templates dont mess up the markup. E.g. if you don't immediately begin your template with the usual `<?php snippet('header') ?>` you would end up having blank spaces in your HTML output.
