### PR TITLE
read() didn't respect content.file.ignore

### DIFF
--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -1695,7 +1695,7 @@ class dir {
    */
   static function read($dir, $ignore=array()) {
     if(!is_dir($dir)) return false;
-    $skip = array_merge(array('.', '..', '.DS_Store'), $ignore);
+    $skip = array_merge(array('.', '..', '.DS_Store'), (array)c::get('content.file.ignore', array()), $ignore);
     return array_diff(scandir($dir),$skip);
   }
 

--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -1695,7 +1695,7 @@ class dir {
    */
   static function read($dir, $ignore=array()) {
     if(!is_dir($dir)) return false;
-    $skip = array_merge(array('.', '..', '.DS_Store'), (array)c::get('content.file.ignore', array()), $ignore);
+    $skip = array_merge(array('.', '..', '.DS_Store', '.svn', '.git', '.htaccess'), (array)c::get('content.file.ignore', array()), $ignore);
     return array_diff(scandir($dir),$skip);
   }
 


### PR DESCRIPTION
c::get('content.file.ignore') wasn't checked by read()
See: https://github.com/bastianallgeier/kirbycms/blame/master/kirby/lib/kirby.php#L1698
Any recommendation? I forgot in which constant the default file ignores were saved..
