### PR TITLE
Corrected incorrect function call in str::sanitize

### DIFF
--- a/kirby/lib/kirby.php
+++ b/kirby/lib/kirby.php
@@ -3173,7 +3173,7 @@ class str {
         $string = self::urlify($string);
         break;
       case 'filename':
-        $string = f::save_name($string);
+        $string = f::safe_name($string);
         break;
     }
 


### PR DESCRIPTION
f::save_name was being called instead of f::safe_name. This typo was causing an error.
